### PR TITLE
Escape blob name before putting in final URL

### DIFF
--- a/keg_storage/backends/azure.py
+++ b/keg_storage/backends/azure.py
@@ -321,7 +321,8 @@ class AzureStorage(base.StorageBackend):
             expiry=expire,
             ip=ip
         )
-        url = urllib.parse.urljoin(self.account_url, '{}/{}'.format(self.bucket, path))
+        escaped_path = urllib.parse.quote(path, safe="")
+        url = urllib.parse.urljoin(self.account_url, '{}/{}'.format(self.bucket, escaped_path))
         return '{}?{}'.format(url, token)
 
     def create_container_url(self, expire: typing.Union[arrow.Arrow, datetime],

--- a/keg_storage/tests/test_backend_azure.py
+++ b/keg_storage/tests/test_backend_azure.py
@@ -267,7 +267,7 @@ class TestAzureStorageUtilities:
         )
         parsed = urlparse.urlparse(url)
         assert parsed.netloc == 'foo.blob.core.windows.net'
-        assert parsed.path == '/test/abc/def.txt'
+        assert parsed.path == '/test/abc%2Fdef.txt'
         qs = urlparse.parse_qs(parsed.query)
 
         assert qs['se'] == ['2019-01-02T03:04:05Z']
@@ -283,7 +283,7 @@ class TestAzureStorageUtilities:
         )
         parsed = urlparse.urlparse(url)
         assert parsed.netloc == 'foo.blob.core.windows.net'
-        assert parsed.path == '/test/abc/def.txt'
+        assert parsed.path == '/test/abc%2Fdef.txt'
         qs = urlparse.parse_qs(parsed.query)
 
         assert qs['se'] == ['2019-01-02T03:04:05Z']
@@ -303,7 +303,7 @@ class TestAzureStorageUtilities:
         )
         parsed = urlparse.urlparse(url)
         assert parsed.netloc == 'foo.blob.core.windows.net'
-        assert parsed.path == '/test/abc/def.txt'
+        assert parsed.path == '/test/abc%2Fdef.txt'
         qs = urlparse.parse_qs(parsed.query)
 
         assert qs['se'] == ['2019-01-02T03:04:05Z']
@@ -320,7 +320,7 @@ class TestAzureStorageUtilities:
         )
         parsed = urlparse.urlparse(url)
         assert parsed.netloc == 'foo.blob.core.windows.net'
-        assert parsed.path == '/test/abc/def.txt'
+        assert parsed.path == '/test/abc%2Fdef.txt'
         qs = urlparse.parse_qs(parsed.query)
 
         assert qs['se'] == ['2019-01-02T03:04:05Z']


### PR DESCRIPTION
The blob name should not be URL escaped when generating the SAS token. But it should be escaped before putting it in the path of the URL.