### PR TITLE
Make filesystem copy work as intended

### DIFF
--- a/keg_storage/backends/filesystem.py
+++ b/keg_storage/backends/filesystem.py
@@ -123,6 +123,10 @@ class LocalFSStorage(base.InternalLinksStorageBackend):
         return LocalFSFile(path, mode)
 
     def copy(self, path: str, new_path: str):
+        self._validate_path(path)
+        self._validate_path(new_path)
+        path = str(self._resolve_path(path))
+        new_path = str(self._resolve_path(new_path))
         return self.put(path, new_path)
 
     def delete(self, path: str):

--- a/keg_storage/tests/test_backend_filesystem.py
+++ b/keg_storage/tests/test_backend_filesystem.py
@@ -197,8 +197,8 @@ class TestLocalFSStorage:
         root = tmp_path.joinpath('root')
         root.mkdir()
 
-        file_path = root.joinpath('file.txt')
-        file_path_copy = root.joinpath('file2.txt')
+        file_path = pathlib.Path('file.txt')
+        file_path_copy = pathlib.Path('file2.txt')
         fs = backends.LocalFSStorage(root)
         file_data1 = os.urandom(100)
 
@@ -206,7 +206,7 @@ class TestLocalFSStorage:
             f.write(file_data1)
         fs.copy(str(file_path), str(file_path_copy))
 
-        with file_path_copy.open('rb') as fp:
+        with root.joinpath(file_path_copy).open('rb') as fp:
             assert fp.read() == file_data1
 
     def test_open_for_writing_creates_directories(self, tmp_path: pathlib.Path):


### PR DESCRIPTION
Ensure paths passed to copy are resolved to the root path

Fixes GH-57
