### PR TITLE
64 inconsistency in parameters

### DIFF
--- a/keg_storage/plugin.py
+++ b/keg_storage/plugin.py
@@ -198,7 +198,7 @@ class StorageOperations:
         """Join the location path with the filename to get the full object path"""
         if filename.startswith('.'):
             filename = filename[1:]
-        return '/'.join([location.value, filename])
+        return '/'.join([location.value, filename]) if location else filename
 
     @staticmethod
     def storage_generate_filename(filename):

--- a/keg_storage/tests/test_views.py
+++ b/keg_storage/tests/test_views.py
@@ -204,6 +204,10 @@ class TestStorageOperations:
         assert ObjectView.storage_prefix_path(StorageLocation.folder1, '.foo.txt') == \
             'Folder-One/foo.txt'
 
+    def test_storage_prefix_path_none_location(self):
+        assert ObjectView.storage_prefix_path(None, 'foo.txt') == \
+               'foo.txt'
+
     def test_storage_get_profile(self):
         assert ObjectView.storage_get_profile('storage.s3') == \
             flask.current_app.storage.get_interface('storage.s3')


### PR DESCRIPTION
Resolves #64
Most methods that call `storage_prefix_path` will also be decorated with `@storage_args()`, so if there's one storage_location set as default at the class level, it will get passed to these methods, but since this is also an static method and might get called from outside, we can handle that by just returning the file name.
